### PR TITLE
Add Hashicorp GH Action maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hashicorp/tf-compliance
+* @hashicorp/tf-compliance @hashicorp/github-actions-maintainers


### PR DESCRIPTION
Adding the Hashicorp GH Action Maintainers as code owners as well.