### PR TITLE
Update code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hashicorp/tf-compliance @hashicorp/github-actions-maintainers
+* @hashicorp/tf-compliance


### PR DESCRIPTION
Removal of Team @hashicorp/github-actions-maintainers from codeowners as they no longer maintain the repo and were helping with the initial setup of the repo.

## PCI review checklist

Update Code owners for only tf-compliance team.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
